### PR TITLE
initial fiberlamp proxy passthrough

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,9 @@ HTTP_PORT=9966
 WSS_PORT=9967
 OSC_PORT=9000
 
+FIBERLAMP_ADDRESS=127.0.0.1
+FIBERLAMP_PORT=4400
+
 # for the http/wss/osc cluster
 DEBUG=worker,server,rhizome*
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "mkdirp": "^0.5.1",
     "modernizr": "^3.3.1",
     "native-dns": "^0.7.0",
+    "node-osc": "^1.2.0",
     "object-assign": "^4.0.1",
     "pocket-physics": "^2.6.1",
     "postcss": "^5.0.18",

--- a/server.js
+++ b/server.js
@@ -64,8 +64,17 @@ if (cluster.isMaster) {
     });
 
     client.on('message', (address, args) => {
-      if (address !== '/fiberlamp') return;
-      const msg = new osc.Message(...[address, ...args]);
+      if (address.indexOf('/fiberlamp') !== 0) return;
+
+      /*
+      /change r g b duration(s)
+      /color r g b
+      /heartbeat r g b t
+      /black
+      /noise
+      */
+
+      const msg = new osc.Message(...[address.replace('/fiberlamp', ''), ...args]);
       sl('sending %o', msg);
       fiberlamp.send(msg);
     });

--- a/server.js
+++ b/server.js
@@ -2,7 +2,9 @@
 
 require('localenv');
 
+const osc = require('node-osc');
 const createRhizome = require('./rhizome-server-repack');
+const RhizomeWSClient = require('rhizome-server').websockets.Client;
 const cluster = require('cluster');
 const numCpus = require('os').cpus().length;
 const debug = require('debug');
@@ -18,7 +20,7 @@ const HTTP_PORT = Number(process.env.HTTP_PORT);
 // returns a simple object to start the rhizome servers
 //
 ///////////////////////////////////////////////////////////////////////////////
-const rhizome = createRhizome({
+const servers = createRhizome({
   wssPort: Number(process.env.WSS_PORT), // should be different than http port
   oscPort: Number(process.env.OSC_PORT),
   outputDir: __dirname + '/tmp',
@@ -38,10 +40,35 @@ if (cluster.isMaster) {
     });
   }
 
-  rhizome.start((err, serverConfig) => {
+  // TODO: not really sure it's worth having rhizome-server-repack/index
+  // when most of the config is neede out here too.
+  servers.start((err, serverConfig) => {
     if (err) throw err;
 
     sl(`${process.pid}: server ports: wss ${serverConfig.wss}, osc ${serverConfig.osc}`);
+
+    const fiberlamp = new osc.Client(
+      process.env.FIBERLAMP_ADDRESS,
+      parseInt(process.env.FIBERLAMP_PORT, 10)
+    );
+
+    const client = new RhizomeWSClient({
+      hostname: '127.0.0.1', // TODO: make this configurable?
+      port: Number(process.env.WSS_PORT),
+    });
+
+    client.start(() => sl('fiberlamp proxy client connected'));
+
+    client.on('connected', () => {
+      client.send('/sys/subscribe', ['/fiberlamp']);
+    });
+
+    client.on('message', (address, args) => {
+      if (address !== '/fiberlamp') return;
+      const msg = new osc.Message(...[address, ...args]);
+      sl('sending %o', msg);
+      fiberlamp.send(msg);
+    });
   });
 }
 


### PR DESCRIPTION
To test:

```
$ node bin/send -p 9967 /fiberlamp blah blah
```

Not sure it's actually forwarded, but the server at least receives
it...

Still need to maybe write some tests for this.